### PR TITLE
Fix feeding button http error 500

### DIFF
--- a/feeding.php
+++ b/feeding.php
@@ -17,8 +17,8 @@ $currentUser = $userService->getCurrentUser();
 $error = '';
 $success = '';
 
-// Get kitten ID from URL
-$kittenId = isset($_GET['kitten_id']) ? (int)$_GET['kitten_id'] : 0;
+// Get kitten ID from URL (accept both kitten_id and cat_id for compatibility)
+$kittenId = isset($_GET['kitten_id']) ? (int)$_GET['kitten_id'] : (isset($_GET['cat_id']) ? (int)$_GET['cat_id'] : 0);
 
 if (!$kittenId) {
     header('Location: dashboard.php');


### PR DESCRIPTION
Fixes HTTP 500 error on `feeding.php` by allowing `cat_id` as an alternative to `kitten_id`.

The `feeding.php` script previously only recognized `kitten_id`, leading to an HTTP 500 error when `cat_id` was used in the URL. This change ensures compatibility and robustness by accepting both parameter names.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b24128c-fa97-4b14-9497-18abb12b36e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b24128c-fa97-4b14-9497-18abb12b36e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

