### PR TITLE
Configure php.ini, add phpmailer, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,31 @@ post_max_size = 10M
 max_execution_time = 300
 memory_limit = 256M
 date.timezone = Europe/Berlin
+; shell_exec für die Installation via Composer/PHPMailer zulassen
+; Entfernen Sie shell_exec aus disable_functions (oder setzen Sie die Zeile leer)
+; Beispiel:
+; disable_functions =
 ```
+
+### PHPMailer installieren (E-Mail Versand)
+
+CatControl nutzt PHPMailer, wenn verfügbar, andernfalls wird auf `mail()` zurückgefallen. Empfohlen ist die Installation von PHPMailer via Composer.
+
+- **Automatisch:** Während der Web-Installation (`install.php`) wird versucht, PHPMailer automatisch via Composer zu installieren, sofern `shell_exec()` erlaubt ist.
+- **Manuell (falls automatisch fehlgeschlagen):**
+
+```bash
+cd /var/www/html/catcontrol
+# Systemweiten Composer verwenden (empfohlen)
+sudo composer require phpmailer/phpmailer:^6
+
+# Oder lokalen Composer nutzen
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php composer-setup.php --quiet
+php -d detect_unicode=0 composer.phar require phpmailer/phpmailer:^6
+```
+
+> Hinweis: Stellen Sie sicher, dass das Webverzeichnis die nötigen Schreibrechte für den Composer-Installationsvorgang besitzt (i.d.R. Benutzer `www-data`).
 
 ### Automatische Backups einrichten
 

--- a/install.php
+++ b/install.php
@@ -189,12 +189,48 @@ return [
                             mkdir($dir, 0755, true);
                         }
                     }
-                    
+
+                    // PHPMailer automatisch installieren (Composer), falls noch nicht vorhanden
+                    $mailerInstalled = false;
+                    $mailerMessage = '';
+                    $projectRoot = __DIR__;
+                    $vendorAutoload = $projectRoot . '/vendor/autoload.php';
+
+                    if (!file_exists($vendorAutoload)) {
+                        if (function_exists('shell_exec')) {
+                            // Versuche System-Composer zu finden
+                            $composerBin = trim((string) shell_exec('command -v composer || which composer 2>/dev/null'));
+                            if (!empty($composerBin)) {
+                                // Composer nutzen, um PHPMailer zu installieren
+                                shell_exec(escapeshellcmd($composerBin) . ' require phpmailer/phpmailer:^6 --no-interaction --no-progress --no-ansi 2>&1');
+                            } else {
+                                // Fallback: lokalen Composer (composer.phar) verwenden
+                                shell_exec('php -r "copy(\'https://getcomposer.org/installer\', \'composer-setup.php\');" 2>&1');
+                                shell_exec('php composer-setup.php --quiet 2>&1');
+                                @unlink('composer-setup.php');
+                                if (file_exists($projectRoot . '/composer.phar')) {
+                                    shell_exec('php composer.phar require phpmailer/phpmailer:^6 --no-interaction --no-progress --no-ansi 2>&1');
+                                }
+                            }
+                        }
+                    }
+
+                    if (file_exists($vendorAutoload)) {
+                        $mailerInstalled = class_exists('PHPMailer\\PHPMailer\\PHPMailer') || strpos((string) @file_get_contents($projectRoot . '/composer.json'), 'phpmailer/phpmailer') !== false;
+                    }
+
+                    if ($mailerInstalled) {
+                        $mailerMessage = '• PHPMailer wurde automatisch installiert und aktiviert';
+                    } else {
+                        $mailerMessage = '• Hinweis: PHPMailer konnte nicht automatisch installiert werden. Führen Sie im Projektverzeichnis folgenden Befehl aus: <code>composer require phpmailer/phpmailer:^6</code>';
+                    }
+
                     echo '<div class="success">
                         ✅ <strong>Installation erfolgreich!</strong><br>
                         • Datenbank wurde erstellt und initialisiert<br>
                         • Konfigurationsdatei wurde erstellt<br>
                         • Upload-Verzeichnisse wurden erstellt<br>
+                        ' . $mailerMessage . '<br>
                         • Standard-Admin-Benutzer: admin / katze<br><br>
                         <strong>Wichtig:</strong> Bitte löschen Sie diese install.php Datei aus Sicherheitsgründen!
                     </div>';

--- a/setup.sh
+++ b/setup.sh
@@ -119,6 +119,20 @@ sed -i 's/max_execution_time = .*/max_execution_time = 300/' $PHP_INI
 sed -i 's/memory_limit = .*/memory_limit = 256M/' $PHP_INI
 sed -i 's/;date.timezone =.*/date.timezone = Europe\/Berlin/' $PHP_INI
 
+# shell_exec erlauben (aus disable_functions entfernen)
+if grep -qE '^\s*disable_functions\s*=' "$PHP_INI"; then
+    sed -i 's/^\(\s*disable_functions\s*=\s*.*\)\bshell_exec\b,\?\s*/\1/' "$PHP_INI"
+    # führendes Komma nach Entfernen bereinigen
+    sed -i 's/^\(\s*disable_functions\s*=\s*\),\s*/\1/' "$PHP_INI"
+    # abschließendes Komma entfernen
+    sed -i 's/\(disable_functions\s*=\s*.*\),\s*$/\1/' "$PHP_INI"
+else
+    echo "disable_functions =" >> "$PHP_INI"
+fi
+
+# Änderungen anwenden
+systemctl reload apache2
+
 print_success "PHP konfiguriert"
 
 print_status "=== Schritt 6: Webverzeichnis erstellen ==="


### PR DESCRIPTION
Allow `shell_exec()` in `php.ini` and automate PHPMailer installation to enable email sending.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bcfc423-defe-4209-b00c-d80b353b69fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bcfc423-defe-4209-b00c-d80b353b69fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

