### PR TITLE
Update setup and readme for remote db access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 CatControl ist eine webbasierte Anwendung zur Verwaltung von jungen Kätzchen, entwickelt für den Einsatz Heimnetzwerken. Das System ermöglicht die Erfassung von Fütterungsdaten, Tierarztbesuchen, Gewichtsstatistiken und vielem mehr.
 <br>Unterstütze Sprachen: Deutsch, Englisch, Französisch
+**Version:** 1.0
 
 <img width="1720" height="864" alt="image" src="https://github.com/user-attachments/assets/a1471571-bc01-40f1-a54b-7b7426f16216" />
 
@@ -94,13 +95,10 @@ sudo chmod 755 /var/www/html/catcontrol
 # In das Webverzeichnis wechseln
 cd /var/www/html/catcontrol
 
-# Projekt herunterladen (ersetzen Sie mit dem tatsächlichen Repository)
-sudo wget https://github.com/IhrRepo/catcontrol/releases/latest/download/catcontrol.zip
-sudo unzip catcontrol.zip
-sudo rm catcontrol.zip
-
-# Oder mit Git:
-# sudo git clone https://github.com/IhrRepo/catcontrol.git .
+# Releasepaket (Version 1.0) auf den Server kopieren und entpacken
+# Beispiel: Datei catcontrol-1.0.zip liegt bereits im aktuellen Verzeichnis
+sudo unzip catcontrol-1.0.zip
+sudo rm catcontrol-1.0.zip
 
 # Berechtigungen setzen
 sudo chown -R www-data:www-data /var/www/html/catcontrol
@@ -193,6 +191,15 @@ MariaDB neu starten:
 ```bash
 sudo systemctl restart mariadb
 ```
+
+Optional: UFW-Regeln für Heimnetz freigeben (Port 3306 nur im LAN):
+```bash
+sudo ufw allow from 192.168.0.0/16 to any port 3306 proto tcp
+sudo ufw allow from 10.0.0.0/8 to any port 3306 proto tcp
+sudo ufw allow from 172.16.0.0/12 to any port 3306 proto tcp
+```
+
+Hinweis (Debian LXC): Das Skript `setup.sh` nimmt diese Anpassungen automatisch vor (bind-address, skip-name-resolve, UFW-Regeln für Port 3306 innerhalb privater Netze).
 
 ### PHP Konfiguration optimieren
 
@@ -448,40 +455,9 @@ Anpassungen:
 </IfModule>
 ```
 
-## 🔄 Updates
+## Version 1.0
 
-### System-Updates
-```bash
-sudo apt update && sudo apt upgrade -y
-sudo systemctl restart apache2 mariadb
-```
-
-### CatControl-Updates
-1. Backup erstellen (siehe Backup-Section)
-2. Neue Version herunterladen
-3. Dateien ersetzen (config-Verzeichnis ausgenommen)
-4. Browser-Cache leeren
-
-### Datenbank-Upgrade (bestehende Installationen)
-
-Führen Sie folgende SQL-Befehle aus, wenn Sie von einer älteren Version aktualisieren:
-
-```sql
--- Nur ausführen, falls Spalte nicht existiert
-ALTER TABLE kittens ADD COLUMN sex ENUM('kater','katze','unbekannt') DEFAULT 'unbekannt';
-
--- Nur ausführen, falls Spalte nicht existiert
-ALTER TABLE kittens ADD COLUMN is_archived BOOLEAN DEFAULT FALSE AFTER is_public;
-
--- Nur ausführen, falls Wert 'gelb' noch nicht im ENUM vorhanden ist
-ALTER TABLE feeding_records MODIFY COLUMN stool_color ENUM('braun','schwarz','orange','rot','grau','gelb','sonstiges');
-
--- Augenstatus Feld ergänzen (falls nicht vorhanden)
-ALTER TABLE feeding_records ADD COLUMN eyes_open BOOLEAN NULL AFTER fitness_level;
-
--- Optional: first_login Default nur für Neuinstallationen ändern
--- (bestehende Tabellen können so bleiben); für Neu-User wird ohnehin 0 gesetzt
-```
+Diese README beschreibt die aktuelle Version 1.0. Separate Update-/Upgrade-Hinweise sind derzeit nicht erforderlich.
 
 ## 📞 Support und Dokumentation
 

--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ cat << "EOF"
 ██║     ██╔══██║   ██║       ██║     ██║   ██║██║╚██╗██║   ██║   ██╔══██╗██║   ██║██║     
 ╚██████╗██║  ██║   ██║       ╚██████╗╚██████╔╝██║ ╚████║   ██║   ██║  ██║╚██████╔╝███████╗
  ╚═════╝╚═╝  ╚═╝   ╚═╝        ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝
-                                                                                           
+                                                                                            
                     🐱 Kätzchen Verwaltungssystem - Setup Script 🐱
 EOF
 echo -e "${NC}"
@@ -153,6 +153,24 @@ mysql -e "FLUSH PRIVILEGES;" 2>/dev/null || true
 
 print_success "MariaDB gesichert"
 
+# MariaDB für Heimnetzwerk freigeben
+print_status "MariaDB für Heimnetzwerk freigeben..."
+CONFIG_FILE="/etc/mysql/mariadb.conf.d/50-server.cnf"
+if [ -f "$CONFIG_FILE" ]; then
+  cp -n "$CONFIG_FILE" "${CONFIG_FILE}.bak" || true
+  if grep -q "^[#[:space:]]*bind-address" "$CONFIG_FILE"; then
+    sed -i "s/^[#[:space:]]*bind-address.*/bind-address = 0.0.0.0/" "$CONFIG_FILE"
+  else
+    awk '1; $0 ~ /^\[mysqld\]/ && !done {print "bind-address = 0.0.0.0"; done=1}' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+  fi
+  if ! grep -q "^[#[:space:]]*skip-name-resolve" "$CONFIG_FILE"; then
+    echo "skip-name-resolve = 1" >> "$CONFIG_FILE"
+  fi
+fi
+
+systemctl restart mariadb
+print_success "MariaDB für Netzwerkzugriff konfiguriert"
+
 print_status "=== Schritt 8: Virtual Host konfigurieren ==="
 
 # Apache Virtual Host erstellen
@@ -194,6 +212,10 @@ ufw default deny incoming
 ufw default allow outgoing
 ufw allow ssh
 ufw allow 'Apache Full'
+# MariaDB-Port nur für private Netze im Heimnetz freigeben
+ufw allow from 192.168.0.0/16 to any port 3306 proto tcp
+ufw allow from 10.0.0.0/8 to any port 3306 proto tcp
+ufw allow from 172.16.0.0/12 to any port 3306 proto tcp
 ufw --force enable
 
 print_success "Firewall konfiguriert"
@@ -242,8 +264,8 @@ mkdir -p $BACKUP_DIR
 # Config-Datei für DB-Passwort lesen
 if [ -f "/var/www/html/catcontrol/config/database.php" ]; then
     DB_PASS=$(php -r "
-    \$config = include '/var/www/html/catcontrol/config/database.php';
-    echo \$config['password'];
+    $config = include '/var/www/html/catcontrol/config/database.php';
+    echo $config['password'];
     ")
     
     # Datenbank-Backup
@@ -335,6 +357,7 @@ echo -e "${BLUE}Server-Informationen:${NC}"
 echo "• Web-Verzeichnis: $WEBROOT"
 echo "• Backup-Verzeichnis: $BACKUP_DIR"
 echo "• Log-Dateien: /var/log/apache2/"
+echo "• MariaDB-LAN-Zugriff: Port 3306 erlaubt aus 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12"
 echo
 echo -e "${BLUE}Nächste Schritte:${NC}"
 echo "1. CatControl-Dateien nach $WEBROOT kopieren"


### PR DESCRIPTION
Configure MariaDB for home network access in `setup.sh` and update `README.md` for version 1.0, removing update notices.

---
<a href="https://cursor.com/background-agent?bcId=bc-45e69865-dd10-40b3-b460-6d9b432115d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45e69865-dd10-40b3-b460-6d9b432115d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

