### PR TITLE
Fix docker build error and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,22 @@ Hinweise:
   - Konfiguration (`config/database.php`): Volume `config_data`
 
 ## Alternative: Installation mit Portainer
-1. In Portainer anmelden und einen neuen Stack erstellen.
-2. Den Inhalt der Datei `docker-compose.yml` aus diesem Projekt in das Portainer-Editorfenster kopieren.
-3. Optional Umgebungsvariablen setzen (z. B. `DB_PASSWORD`).
-4. Stack deployen.
-5. Nach dem Start: `http://<Portainer-Host>:8080/install.php` im Browser aufrufen und die Installation ausführen.
+
+Es gibt zwei Möglichkeiten:
+
+1) Portainer-Stack mit Git-Remote-Build (kein lokales Dockerfile nötig)
+- In Portainer einen neuen Stack erstellen und den Inhalt aus `docker-compose.portainer.yml` einfügen.
+- Diese Variante baut das `web`-Image direkt aus dem GitHub-Repository (`context: https://github.com/worksasdesigned/CatControl2.git#main`) und nutzt das darin enthaltene `docker/php/Dockerfile`.
+- Optional Umgebungsvariablen setzen (z. B. `DB_PASSWORD`).
+- Stack deployen und anschließend `http://<Portainer-Host>:8080/install.php` aufrufen.
+
+2) Portainer „Git repository“-Stack
+- In Portainer beim Stack „Git repository“ auswählen.
+- Repository URL: `https://github.com/worksasdesigned/CatControl2.git`
+- Reference/Branch: `main`
+- Compose path: `docker-compose.yml`
+- Optional Environment (z. B. `DB_PASSWORD`) setzen.
+- Deploy Stack. Portainer klont das Repo und baut anhand der enthaltenen Dockerfiles.
 
 ## Details zur Installation (install.php)
 - `install.php` erstellt (falls nötig) die Datenbanktabellen und speichert die DB-Verbindung in `config/database.php`.

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: mariadb:11.4
+    container_name: catcontrol_db
+    restart: unless-stopped
+    environment:
+      - MYSQL_DATABASE=catcontrol
+      - MYSQL_USER=phpuser
+      - MYSQL_PASSWORD=${DB_PASSWORD:-changeme123}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-rootpassword}
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "phpuser", "-p${DB_PASSWORD:-changeme123}"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  web:
+    build:
+      context: https://github.com/worksasdesigned/CatControl2.git#main
+      dockerfile: docker/php/Dockerfile
+    container_name: catcontrol_web
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - DB_HOST=db
+      - DB_NAME=catcontrol
+      - DB_USER=phpuser
+      - DB_PASSWORD=${DB_PASSWORD:-changeme123}
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@localhost}
+      - ALLOW_INSTALL=1
+      - APACHE_DOCUMENT_ROOT=/var/www/html
+    ports:
+      - "8080:80"
+    volumes:
+      - uploads_data:/var/www/html/uploads
+      - config_data:/var/www/html/config
+    restart: unless-stopped
+
+volumes:
+  db_data:
+  uploads_data:
+  config_data:


### PR DESCRIPTION
Enable direct Portainer deployment by adding a remote-build Docker Compose file and updating README instructions.

The original `docker-compose.yml` requires a local build context (e.g., `docker/php/Dockerfile`), which is not available when deploying via Portainer's 'Web Editor' stack. This PR introduces `docker-compose.portainer.yml` which builds directly from the GitHub repository, and updates the README with clear Portainer deployment options, including using Portainer's 'Git repository' feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-01182395-31ac-46a3-97f7-f223d2eac496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01182395-31ac-46a3-97f7-f223d2eac496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

