### PR TITLE
Fix docker build error and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,19 @@ Hinweise:
   - Konfiguration (`config/database.php`): Volume `config_data`
 
 ## Alternative: Installation mit Portainer
-1. In Portainer anmelden und einen neuen Stack erstellen.
-2. Den Inhalt der Datei `docker-compose.yml` aus diesem Projekt in das Portainer-Editorfenster kopieren.
-3. Optional Umgebungsvariablen setzen (z. B. `DB_PASSWORD`).
-4. Stack deployen.
-5. Nach dem Start: `http://<Portainer-Host>:8080/install.php` im Browser aufrufen und die Installation ausführen.
+
+**Option A (empfohlen) – Repository**
+1. In Portainer einen neuen Stack erstellen und "Repository" wählen.
+2. Repository-URL: `https://github.com/worksasdesigned/CatControl2`
+3. Compose-Dateipfad: `docker-compose.yml`
+4. Branch/Reference: `Master`
+5. Optional: Umgebungsvariablen setzen (z. B. `DB_PASSWORD`).
+6. Deployen und danach `http://<Portainer-Host>:8080/install.php` im Browser öffnen.
+
+**Option B – Web-Editor (YAML einfügen)**
+- Der Web-Editor hat keinen Build-Kontext. Dadurch entsteht der Fehler "open Dockerfile: no such file or directory", wenn nur das YAML eingefügt wird.
+- Verwenden Sie stattdessen die Datei `docker-compose.portainer.yml` aus diesem Repo (sie nutzt einen Git-Build-Kontext). Inhalt in den Editor kopieren und deployen.
+- Falls der Build dennoch fehlschlägt, verwenden Sie Option A.
 
 ## Details zur Installation (install.php)
 - `install.php` erstellt (falls nötig) die Datenbanktabellen und speichert die DB-Verbindung in `config/database.php`.

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: mariadb:11.4
+    container_name: catcontrol_db
+    restart: unless-stopped
+    environment:
+      - MYSQL_DATABASE=catcontrol
+      - MYSQL_USER=phpuser
+      - MYSQL_PASSWORD=${DB_PASSWORD:-changeme123}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-rootpassword}
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "phpuser", "-p${DB_PASSWORD:-changeme123}"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  web:
+    build:
+      context: https://github.com/worksasdesigned/CatControl2.git#Master
+      dockerfile: docker/php/Dockerfile
+    container_name: catcontrol_web
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - DB_HOST=db
+      - DB_NAME=catcontrol
+      - DB_USER=phpuser
+      - DB_PASSWORD=${DB_PASSWORD:-changeme123}
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@localhost}
+      - ALLOW_INSTALL=1
+      - APACHE_DOCUMENT_ROOT=/var/www/html
+    ports:
+      - "8080:80"
+    volumes:
+      - uploads_data:/var/www/html/uploads
+      - config_data:/var/www/html/config
+    restart: unless-stopped
+
+volumes:
+  db_data:
+  uploads_data:
+  config_data:


### PR DESCRIPTION
Add a Portainer-compatible Docker Compose file and update the README to enable direct deployment in Portainer and resolve "Dockerfile not found" errors.

When deploying the original `docker-compose.yml` via Portainer's web editor, the build context (including the Dockerfile) is missing, leading to build failures. This PR introduces `docker-compose.portainer.yml` which explicitly sets the build context to the GitHub repository, allowing successful builds in the web editor. The README is also updated to guide users on the recommended repository-based deployment or the new file for web editor use.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2177e89-6f58-4b44-b5f9-d2d74fb21f6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2177e89-6f58-4b44-b5f9-d2d74fb21f6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

