### PR TITLE
Fix docker deployment and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ CatControl ist eine Webanwendung zur Verwaltung von Kätzchen. Diese Anleitung b
 - 1–2 GB freier Speicherplatz für Container und Uploads
 
 ## Schnellstart (Docker Compose)
-1. Repository-Dateien auf Ihren Host kopieren (dieses Verzeichnis ist der Compose-Kontext).
+1. Repository klonen und in den Ordner wechseln:
+   ```bash
+   git clone https://github.com/worksasdesigned/CatControl2.git
+   cd CatControl2
+   ```
 2. Optional: Datenbank-Passwort setzen (wenn nicht, wird `changeme123` verwendet):
    ```bash
    export DB_PASSWORD="meinPasswort"
@@ -17,7 +21,7 @@ CatControl ist eine Webanwendung zur Verwaltung von Kätzchen. Diese Anleitung b
    docker compose up -d --build
    ```
 4. Browser öffnen und Installation ausführen:
-   - URL: `http://localhost:8080/install.php`
+   - URL: `http://localhost:8280/install.php`
    - Voreinstellungen:
      - Host: `db`
      - DB-Name: `catcontrol`
@@ -26,7 +30,7 @@ CatControl ist eine Webanwendung zur Verwaltung von Kätzchen. Diese Anleitung b
 5. Nach erfolgreicher Installation die Datei `install.php` entfernen (oder später löschen), um versehentliche Neuinstallationen zu vermeiden.
 
 Hinweise:
-- Die Anwendung ist nach der Installation unter `http://localhost:8080` erreichbar.
+- Die Anwendung ist nach der Installation unter `http://localhost:8280` erreichbar.
 - DB-Zugriff vom Host (z. B. Adminer/HeidiSQL): Host `localhost`, Port `3306`, Benutzer `phpuser`, Passwort `${DB_PASSWORD}`.
 - Persistente Daten:
   - Datenbank: Volume `db_data`
@@ -35,12 +39,12 @@ Hinweise:
 
 ## Alternative: Installation mit Portainer
 
-Es gibt zwei Möglichkeiten:
+Wichtig: Das Standard-Compose `docker-compose.yml` erwartet lokale Dateien (z. B. `docker/php/Dockerfile`) und funktioniert im Portainer-Webeditor nicht. Das führt zur Fehlermeldung „failed to read dockerfile: open Dockerfile: no such file or directory“. Verwenden Sie stattdessen eine der folgenden Optionen:
 
-1) Portainer-Stack mit Git-Remote-Build (kein lokales Dockerfile nötig)
+1) Webeditor mit Remote-Git-Build (empfohlen, schnell zu starten)
 - In Portainer einen neuen Stack erstellen und den Inhalt aus `docker-compose.portainer.yml` einfügen.
 - Diese Variante baut das `web`-Image direkt aus dem GitHub-Repository (`context: https://github.com/worksasdesigned/CatControl2.git#main`) und nutzt das darin enthaltene `docker/php/Dockerfile`.
-- Optional Umgebungsvariablen setzen (z. B. `DB_PASSWORD`).
+- Optional Umgebungsvariablen setzen (z. B. `DB_PASSWORD`) im Bereich „Environment variables“.
 - Stack deployen und anschließend `http://<Portainer-Host>:8080/install.php` aufrufen.
 
 2) Portainer „Git repository“-Stack
@@ -50,6 +54,8 @@ Es gibt zwei Möglichkeiten:
 - Compose path: `docker-compose.yml`
 - Optional Environment (z. B. `DB_PASSWORD`) setzen.
 - Deploy Stack. Portainer klont das Repo und baut anhand der enthaltenen Dockerfiles.
+
+Hinweis: Ein vorgefertigtes Container-Image wird derzeit nicht veröffentlicht; der Build erfolgt aus dem Quellcode des Repositories.
 
 ## Details zur Installation (install.php)
 - `install.php` erstellt (falls nötig) die Datenbanktabellen und speichert die DB-Verbindung in `config/database.php`.


### PR DESCRIPTION
Clarify Portainer deployment instructions and local Docker Compose quickstart in `README.md` to resolve "Dockerfile not found" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c31a0b38-67cc-4c99-ab90-825eb301810b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c31a0b38-67cc-4c99-ab90-825eb301810b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

